### PR TITLE
Removing system libraries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,2 @@
 requests
 colorama
-os
-time
-Fore
-fore
-init


### PR DESCRIPTION
These are installed by default and causes pip install -r requirements.txt to fail.